### PR TITLE
libresoc: Fix The duplication

### DIFF
--- a/content/stands/the_libresoc_project__a_hybrid_3d_cpu_vpu_gpu.md
+++ b/content/stands/the_libresoc_project__a_hybrid_3d_cpu_vpu_gpu.md
@@ -24,7 +24,7 @@ showcase: To learn that there exists an alternative to proprietary processors fr
   Intel, ARM and AMD, and that yes, they can actually be part of making that happen.
 themes:
 - Multimedia and graphics
-title: 'The LibreSOC Project'
+title: 'LibreSOC Project'
 website: http://libre-soc.org
 show_on_overview: true
 chatroom: libresoc


### PR DESCRIPTION
Page show "The the" the can be easly fixed by removing "the" prefix in title page

Relate-to: https://stands.fosdem.org/stands/the_libresoc_project__a_hybrid_3d_cpu_vpu_gpu/
Signed-off-by: Philippe Coval <rzr@users.sf.net>