### PR TITLE
update videos with images and links to YT, re-arranged stuff to fit nicer.

### DIFF
--- a/content/stands/nextcloud_hub__self-hosted__fully_open-source_file_sync__collaboration___communication_platform.md
+++ b/content/stands/nextcloud_hub__self-hosted__fully_open-source_file_sync__collaboration___communication_platform.md
@@ -8,93 +8,7 @@ layout: stand
 logo: /stands/nextcloud/logo.png
 new_this_year: "
 <p>To find out what's new in Nextcloud over 2020, it's probably best to check out our talk on that subject. But we'll also happily share some basics here.</p>
-<h3>Releases</h3>
-<h4>Nextcloud hub 20</h4>
-<p>The three biggest features we introduced with Nextcloud 20 are:</p>
-<ul style=\"padding-inline-start: 20px;\">
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🏁 Our new dashboard provides a great starting point for the day with over a dozen widgets ranging from Twitter and Github to Moodle and Zammad already available</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔍 Search was unified, bringing search results of Nextcloud apps as well as external services like Gitlab, Jira and Discourse in one place</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗨 Talk introduced bridging to other platforms including MS Teams, Slack, IRC, Matrix and a dozen others</li>
-</ul>
-<p style=\"margin-top: 20px;\" >👾 Some other improvements we want to highlight include:</p>
-<ul style=\"padding-inline-start: 20px; margin-top: 15px;\">
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📢 Notifications and Activities were brought together, making sure you won’t miss anything important</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🟢 We added a ‘status’ setting so you can communicate to other users what you are up to</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗨 Talk also brings dashboard and search integration, emoji picker, upload view, camera and microphone settings, mute and more</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📅 Calendar integrates in dashboard and search, introduced a list view and design improvements</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📫 Mail introduces threaded view, mailbox management and more</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗂 Deck integrates with dashboard and search, introduces Calendar integration, modal view for card editing and series of smaller improvements</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">↕ Flow adds push notification and webhooks so other web apps can easily integrate with Nextcloud</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗒 Text introduced direct linking to files in Nextcloud</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗄 Files lets you add a description to public link shares</li>
-</ul>
-<p style=\"margin-top: 20px;\" ><a href=\"https://nextcloud.com/blog/nextcloud-hub-20-debuts-dashboard-unifies-search-and-notifications-integrates-with-other-technologies/\">Read the full announcement on our blog.</a></p>
-<h4>Nextcloud Hub 19</h4>
-<p>Nextcloud Hub v19, code name “home office”, represents a big step forward for remote collaboration in teams. This release brought document collaboration to video chats, introduced password-less login and improves performance.</p>
-<p>A quick overview of what is new:</p>
-<ul style=\"padding-inline-start: 20px;\">
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔒 password-less authentication and many other security measures</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📝 Talk 9 with built-in office document editing courtesy of Collabora, a grid view & more</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🚀 MUCH improved performance, 📆 Deck integration in Calendar, 🙇 guest account groups and more!</li>
-</ul>
-<p style=\"margin-top: 20px;\" >We also released our high performance back-end for Talk under an open source license and introduced improvements in Deck, Mail, Calendar and other apps.</p>
-<p style=\"margin-top: 20px;\" >Read the <a class=\"hyperlink\" href=\"https://nextcloud.com/blog/nextcloud-hub-brings-productivity-to-home-office/\">release announcement</a> for more details.</p>
-<h4>Nextcloud Hub 18 announcement</h4>
-<p>Nextcloud Hub is the first completely integrated on-premises content collaboration platform on the market, ready for a new generation of users who expect seamless online collaboration capabilities out of the box.</p>
-<p>With this release, we made a change to what we ship. Nextcloud 17 is now Nextcloud Hub 18. Nextcloud Hub comes with a number of new apps which get installed by default on installation (but not shipped as part of the tarball/zip).</p>
-<p>A quick overview of what is new:</p>
-<ul style=\"padding-inline-start: 20px;\">
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📁 Files - features an improved sidebar, accepting internal shares &amp; folder owner transfership
-<ul style=\"padding-inline-start: 20px;\">
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗃 Workspaces brings context to your folders, facilitating collaboration in one place.</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔏 File locking prevents conflicts editing shared files with others</li>
-</ul></li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🤖 Flow - Brings extensive, easy to use workflow capabilities to Nextcloud. Automatically turn documents in PDFs, send messages to chat rooms and more!</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📝 ONLYOFFICE - Built in ONLYOFFICE makes collaborative editing of Microsoft Office documents accessible to everyone</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📸 Photos - A brand new image gallery makes finding, browsing and sharing your images easier than ever before.</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📅 Calendar 2.0 - Calendar 2.0 books Talk meetings, brings busy view for meetings and resource booking and more</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📩 Mail - Mail 1.0 recognizes itineraries, handles rich text mails and more</li>
-<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗣 Talk - rewritten user interface brings message delivery notifications, circles support, message replies and flow integration</li>
-</ul>
-<p style=\"margin-top: 20px;\" >Read the <a class=\"hyperlink\" href=\"https://nextcloud.com/blog/the-new-standard-in-on-premises-team-collaboration-nextcloud-hub/\">release announcement</a> for more details.</p>
-
-<h4>More releases</h4>
-<p>There are many more things the Nextcloud community releases - independent but very cool apps like <a href\"https://twitter.com/Nextclouders/status/1349648706237325314\">Notes for Android</a> or the brand new <a href\"https://twitter.com/the_picrew/status/1349710415064944645\">Podcasts app</a>. And of course our mobile and desktop apps! Here some highlights from 2020.
-<ul>
-<li><a href=\"https://nextcloud.com/blog/minor-release-of-desktop-client-a-recap-of-2020-features-and-gifts-for-nextcloud-users/\">Desktop client 2020 recap</a></li>
-<li><a href=\"https://nextcloud.com/blog/unsung-heroes-of-the-nextcloud-community-biswajit-das-developing-a-nextcloud-bookmarks-android-client/\">Nextcloud Bookmarks (author interview)</a></li>
-<li><a href=\"https://nextcloud.com/blog/nextcloud-ios-client-turns-3-0-10-new-transfer-view-grid-view-recent-view-on-your-mobile-copy-pasting-between-different-users-and-more/\">Final iOS release of the year</a></li>
-<li><a href=\"https://nextcloud.com/blog/nextcloud-3-13-1-for-android-is-out-plus-tips-about-auto-upload-for-existing-images-and-more/\">Final Android release of 2020</a></li>
-<li><a href=\"https://nextcloud.com/blog/production-ready-end-to-end-encryption-and-new-user-interface-arrive-with-nextcloud-desktop-client-3-0/\">Did you know end-to-end encryption is now here?</a></li>
-<li><a href=\"https://nextcloud.com/blog/nextcloud-forms-is-here-to-take-on-gafam/\">We released Nextcloud Forms to replace Google Forms.</a></li>
-<li><a href=\"https://nextcloud.com/blog/nextcloud-mail-introduces-machine-learning-for-priority-inbox/\">Nextcloud Mail introduced a machine learning powered priority inbox</a></li>
-<li><a href=\"https://nextcloud.com/blog/nextcloud-deck-1-0-available-today-plus-deck-for-android/\">Nextcloud Deck made it to 1.0!</a></li>"
-showcase: "
-<h3>Introductions</h3>
-<p>What is a content collaboration platform? Why on premises and open source? Let's answer that with a question!</p>
-<div class=\"row\">
-    <div class=\"col-md-8\">
-        <p>Where is your data? Where are the pictures from your last vacation on the beach, where is your contact list, where are the last chats you had with your loved ones? Who has access to that data, who can see it, who can download it, who can modify or delete it? Do you trust the services you use to take care of your data?
-
-        <p>Your data represents who you are and can easily be abused.<br /> <strong>We want this to change.</strong></p>
-        <p>We at Nextcloud believe that you have a right to decide what happens with your data. We believe that you should be able to have as much control as possible on what belongs to no one else but you.</p>
-    </div>
-    <div class=\"col-md-4\">
-        <img style=\"width: 100%; height: auto; float: right;\" src=\"/stands/nextcloud/who_owns_your_data.gif\">
-    </div>
-</div>
-<h4>Protecting your rights</h4>
-<div class=\"row\">
-    <div class=\"col-md-8\">
-        <p>How does that work? First, Nextcloud is an Open Source private cloud software, which means that anyone can read the code, and make sure it keeps your data safe. And second, at Nextcloud, we don't force you to pick our own infrastructure or servers like the big famous public clouds do. You can run Nextcloud yourself, at home or in a data center on rented space. You can buy ready-to-go devices with Nextcloud or pick a provider who rents out space to you!</p>
-
-        <p>We built a software that does everything you expect from a cloud - from syncing and sharing files to editing documents, storing passwords, calendars and bookmarks and reading mail. But YOU decide where the data is and who has access!</p>
-    </div>
-    <div class=\"col-md-4\">
-        <img style=\"width: 100%; height: auto;\" src=\"/stands/nextcloud/dashboard.png\">
-    </div>
-</div>
-
+<p>But first, what it looks like today!</p>
 <h4>What it looks like</h4>
 
 <p>We created some videos to give you an idea of what Nextcloud Hub looks like!</p>
@@ -168,7 +82,97 @@ You can find them on YouTube (click image for redirect), we're currently working
 </ul>
 <p>Also, did you know we <a href=\"https://nextcloud.com/podcast\">have a podcast?</a></p>
 
-<p>We have a virtual stand and we'll try and answer questions you have in the chat room. There's a talk about Nextcloud in 2020 and of course you can check the videos above.</p>
+
+
+<h3>Releases</h3>
+<h4>Nextcloud hub 20</h4>
+<p>The three biggest features we introduced with Nextcloud 20 are:</p>
+<ul style=\"padding-inline-start: 20px;\">
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🏁 Our new dashboard provides a great starting point for the day with over a dozen widgets ranging from Twitter and Github to Moodle and Zammad already available</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔍 Search was unified, bringing search results of Nextcloud apps as well as external services like Gitlab, Jira and Discourse in one place</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗨 Talk introduced bridging to other platforms including MS Teams, Slack, IRC, Matrix and a dozen others</li>
+</ul>
+<p style=\"margin-top: 20px;\" >👾 Some other improvements we want to highlight include:</p>
+<ul style=\"padding-inline-start: 20px; margin-top: 15px;\">
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📢 Notifications and Activities were brought together, making sure you won’t miss anything important</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🟢 We added a ‘status’ setting so you can communicate to other users what you are up to</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗨 Talk also brings dashboard and search integration, emoji picker, upload view, camera and microphone settings, mute and more</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📅 Calendar integrates in dashboard and search, introduced a list view and design improvements</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📫 Mail introduces threaded view, mailbox management and more</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗂 Deck integrates with dashboard and search, introduces Calendar integration, modal view for card editing and series of smaller improvements</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">↕ Flow adds push notification and webhooks so other web apps can easily integrate with Nextcloud</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗒 Text introduced direct linking to files in Nextcloud</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗄 Files lets you add a description to public link shares</li>
+</ul>
+<p style=\"margin-top: 20px;\" ><a href=\"https://nextcloud.com/blog/nextcloud-hub-20-debuts-dashboard-unifies-search-and-notifications-integrates-with-other-technologies/\">Read the full announcement on our blog.</a></p>
+<h4>Nextcloud Hub 19</h4>
+<p>Nextcloud Hub v19, code name “home office”, represents a big step forward for remote collaboration in teams. This release brought document collaboration to video chats, introduced password-less login and improves performance.</p>
+<p>A quick overview of what is new:</p>
+<ul style=\"padding-inline-start: 20px;\">
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔒 password-less authentication and many other security measures</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📝 Talk 9 with built-in office document editing courtesy of Collabora, a grid view & more</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🚀 MUCH improved performance, 📆 Deck integration in Calendar, 🙇 guest account groups and more!</li>
+</ul>
+<p style=\"margin-top: 20px;\" >We also released our high performance back-end for Talk under an open source license and introduced improvements in Deck, Mail, Calendar and other apps.</p>
+<p style=\"margin-top: 20px;\" >Read the <a class=\"hyperlink\" href=\"https://nextcloud.com/blog/nextcloud-hub-brings-productivity-to-home-office/\">release announcement</a> for more details.</p>
+<h4>Nextcloud Hub 18 announcement</h4>
+<p>Nextcloud Hub is the first completely integrated on-premises content collaboration platform on the market, ready for a new generation of users who expect seamless online collaboration capabilities out of the box.</p>
+<p>With this release, we made a change to what we ship. Nextcloud 17 is now Nextcloud Hub 18. Nextcloud Hub comes with a number of new apps which get installed by default on installation (but not shipped as part of the tarball/zip).</p>
+<p>A quick overview of what is new:</p>
+<ul style=\"padding-inline-start: 20px;\">
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📁 Files - features an improved sidebar, accepting internal shares &amp; folder owner transfership
+<ul style=\"padding-inline-start: 20px;\">
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗃 Workspaces brings context to your folders, facilitating collaboration in one place.</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🔏 File locking prevents conflicts editing shared files with others</li>
+</ul></li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🤖 Flow - Brings extensive, easy to use workflow capabilities to Nextcloud. Automatically turn documents in PDFs, send messages to chat rooms and more!</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📝 ONLYOFFICE - Built in ONLYOFFICE makes collaborative editing of Microsoft Office documents accessible to everyone</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📸 Photos - A brand new image gallery makes finding, browsing and sharing your images easier than ever before.</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📅 Calendar 2.0 - Calendar 2.0 books Talk meetings, brings busy view for meetings and resource booking and more</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">📩 Mail - Mail 1.0 recognizes itineraries, handles rich text mails and more</li>
+<li style=\"list-style: none; list-style-image: none; margin-top: 8px;\">🗣 Talk - rewritten user interface brings message delivery notifications, circles support, message replies and flow integration</li>
+</ul>
+<p style=\"margin-top: 20px;\" >Read the <a class=\"hyperlink\" href=\"https://nextcloud.com/blog/the-new-standard-in-on-premises-team-collaboration-nextcloud-hub/\">release announcement</a> for more details.</p>
+
+<h4>More releases</h4>
+<p>There are many more things the Nextcloud community releases - independent but very cool apps like <a href\"https://twitter.com/Nextclouders/status/1349648706237325314\">Notes for Android</a> or the brand new <a href\"https://twitter.com/the_picrew/status/1349710415064944645\">Podcasts app</a>. And of course our mobile and desktop apps! Here some highlights from 2020.
+<ul>
+<li><a href=\"https://nextcloud.com/blog/minor-release-of-desktop-client-a-recap-of-2020-features-and-gifts-for-nextcloud-users/\">Desktop client 2020 recap</a></li>
+<li><a href=\"https://nextcloud.com/blog/unsung-heroes-of-the-nextcloud-community-biswajit-das-developing-a-nextcloud-bookmarks-android-client/\">Nextcloud Bookmarks (author interview)</a></li>
+<li><a href=\"https://nextcloud.com/blog/nextcloud-ios-client-turns-3-0-10-new-transfer-view-grid-view-recent-view-on-your-mobile-copy-pasting-between-different-users-and-more/\">Final iOS release of the year</a></li>
+<li><a href=\"https://nextcloud.com/blog/nextcloud-3-13-1-for-android-is-out-plus-tips-about-auto-upload-for-existing-images-and-more/\">Final Android release of 2020</a></li>
+<li><a href=\"https://nextcloud.com/blog/production-ready-end-to-end-encryption-and-new-user-interface-arrive-with-nextcloud-desktop-client-3-0/\">Did you know end-to-end encryption is now here?</a></li>
+<li><a href=\"https://nextcloud.com/blog/nextcloud-forms-is-here-to-take-on-gafam/\">We released Nextcloud Forms to replace Google Forms.</a></li>
+<li><a href=\"https://nextcloud.com/blog/nextcloud-mail-introduces-machine-learning-for-priority-inbox/\">Nextcloud Mail introduced a machine learning powered priority inbox</a></li>
+<li><a href=\"https://nextcloud.com/blog/nextcloud-deck-1-0-available-today-plus-deck-for-android/\">Nextcloud Deck made it to 1.0!</a></li>"
+showcase: "
+<h3>Introductions</h3>
+<p>What is a content collaboration platform? Why on premises and open source? Let's answer that with a question!</p>
+<div class=\"row\">
+    <div class=\"col-md-8\">
+        <p>Where is your data? Where are the pictures from your last vacation on the beach, where is your contact list, where are the last chats you had with your loved ones? Who has access to that data, who can see it, who can download it, who can modify or delete it? Do you trust the services you use to take care of your data?
+
+        <p>Your data represents who you are and can easily be abused.<br /> <strong>We want this to change.</strong></p>
+        <p>We at Nextcloud believe that you have a right to decide what happens with your data. We believe that you should be able to have as much control as possible on what belongs to no one else but you.</p>
+    </div>
+    <div class=\"col-md-4\">
+        <img src=\"/stands/nextcloud/who_owns_your_data.gif\" class=\"img-fluid\">
+    </div>
+</div>
+<h4>Protecting your rights</h4>
+<div class=\"row\">
+    <div class=\"col-md-8\">
+        <p>How does that work? First, Nextcloud is an Open Source private cloud software, which means that anyone can read the code, and make sure it keeps your data safe. And second, at Nextcloud, we don't force you to pick our own infrastructure or servers like the big famous public clouds do. You can run Nextcloud yourself, at home or in a data center on rented space. You can buy ready-to-go devices with Nextcloud or pick a provider who rents out space to you!</p>
+
+        <p>We built a software that does everything you expect from a cloud - from syncing and sharing files to editing documents, storing passwords, calendars and bookmarks and reading mail. But YOU decide where the data is and who has access!</p>
+    </div>
+    <div class=\"col-md-4\">
+        <img  src=\"/stands/nextcloud/dashboard.png\" class=\"img-fluid\">
+    </div>
+</div>
+
+
+<p>We have a virtual stand and we'll try and answer questions you have in the chat room. There's a talk about Nextcloud in 2020 and of course you can check the videos below.</p>
 "
 themes:
 - World wide web

--- a/content/stands/nextcloud_hub__self-hosted__fully_open-source_file_sync__collaboration___communication_platform.md
+++ b/content/stands/nextcloud_hub__self-hosted__fully_open-source_file_sync__collaboration___communication_platform.md
@@ -99,28 +99,42 @@ showcase: "
 
 <p>We created some videos to give you an idea of what Nextcloud Hub looks like!</p>
 
+You can find them on YouTube (click image for redirect), we're currently working on getting them also embedded below.
+
 <div class=\"row\">
     <div class=\"col-md-6\">
-        <stream src=\"eb1384b4fa48d8f47abdec5051bc922d\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/hub-video.png\"></stream>
-        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=eb1384b4fa48d8f47abdec5051bc922d\"></script>
+        <a href=\"https://www.youtube.com/watch?v=I8GtygCoNcY\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/hub-video.png\" /></a><br /> Nextcloud Hub overview
+        <!--<stream src=\"eb1384b4fa48d8f47abdec5051bc922d\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/hub-video.png\"></stream>
+        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=eb1384b4fa48d8f47abdec5051bc922d\"></script>-->
     </div>
     <div class=\"col-md-6\">
-        <stream src=\"4b66104c586170a4dc5b6ebbed80b193\" controls preload poster=\"https://nextcloud.com/wp-content/themes/next//assets/img/features/homeoffice-video.png\">
-        </stream> <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=4b66104c586170a4dc5b6ebbed80b193\"></script>
+        <a href=\"https://www.youtube.com/watch?v=FMgBD3Jr33Y\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next//assets/img/features/homeoffice-video.png\" /></a><br /> Nextcloud in working-from-home
+        <!--<stream src=\"4b66104c586170a4dc5b6ebbed80b193\" controls preload poster=\"https://nextcloud.com/wp-content/themes/next//assets/img/features/homeoffice-video.png\">
+        </stream> <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=4b66104c586170a4dc5b6ebbed80b193\"></script>-->
     </div>
 </div>
 <div style=\"margin-top:20px;\" class=\"row\">
-    <div class=\"col-md-4\">
-        <stream src=\"fa1b52828b602f72cf1bcfab61f74fb4\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/files-video.png\"></stream>
-        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=fa1b52828b602f72cf1bcfab61f74fb4\"></script>
+    <div class=\"col-md-6\">
+        <a href=\"https://www.youtube.com/watch?v=W1-W5KTWNdM\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/files-video.png\" /></a><br /> Nextcloud Files
+        <!--<stream src=\"fa1b52828b602f72cf1bcfab61f74fb4\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/files-video.png\"></stream>
+        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=fa1b52828b602f72cf1bcfab61f74fb4\"></script>-->
     </div>
-    <div class=\"col-md-4\">
-        <stream src=\"58bf7b0f3ae662ee1d6b368099c8c94f\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/talk-video.png\"></stream>
-        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=58bf7b0f3ae662ee1d6b368099c8c94f\"></script>
+    <div class=\"col-md-6\">
+        <a href=\"https://www.youtube.com/watch?v=dDUid67CeRQ\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/talk-video.png\" /></a><br /> Nextcloud Talk
+        <!--<stream src=\"58bf7b0f3ae662ee1d6b368099c8c94f\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/talk-video.png\"></stream>
+        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=58bf7b0f3ae662ee1d6b368099c8c94f\"></script>-->
     </div>
-    <div class=\"col-md-4\">
-    <stream src=\"3e135d59fff771d1909c4b8d588d5800\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/groupware-video.png\"></stream>
-    <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=3e135d59fff771d1909c4b8d588d5800\"></script>
+</div>
+<div style=\"margin-top:20px;\" class=\"row\">
+    <div class=\"col-md-6\">
+        <a href=\"https://www.youtube.com/watch?v=k5e1Ut6MytE\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/groupware-video.png\" /></a><br /> Nextcloud Groupware
+        <!--<stream src=\"3e135d59fff771d1909c4b8d588d5800\" controls poster=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/groupware-video.png\"></stream>
+        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=3e135d59fff771d1909c4b8d588d5800\"></script>-->
+    </div>
+    <div class=\"col-md-6\">
+        <a href=\"https://www.youtube.com/watch?v=nxX_Z6BKySw\"><img class=\"img-fluid\" src=\"https://nextcloud.com/wp-content/themes/next/assets/img/features/documents-video.png\" /></a><br /> Nextcloud Document editing
+        <!--<stream src=\"6644f6c1e7c0a5e3ff5b877e07ed1dea\" controls poster=\"<?php bloginfo('template_directory'); ?>/assets/img/features/documents-video.png\"></stream>
+        <script data-cfasync=\"false\" defer type=\"text/javascript\" src=\"https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=6644f6c1e7c0a5e3ff5b877e07ed1dea\"></script>-->
     </div>
 </div>
 <p style=\"margin-top: 20px;\">Of course, there's a lot more to learn about Nextcloud, and we've collected some links for you to our website:</p>


### PR DESCRIPTION
Disabled our embedded videos as they don't work anyway, added a note that we're working on getting the vids online (currently not working but that's OK) and instead use images as placeholders with links to YouTube - and a warning that that's where the links go to.
At least it looks nice!

![screencapture-localhost-1313-stands-nextcloud-hub-self-hosted-fully-open-source-file-sync-collaboration-communication-platform-2021-02-06-11_04_55](https://user-images.githubusercontent.com/551757/107115196-2e268d80-686b-11eb-876c-011fb521d659.png)

Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>