### PR TITLE
Revert "remove failing module: openuk"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -149,12 +149,10 @@
 	path = static/stands/openuk
 	url = https://github.com/OpenUK/fosdem-static.git
 	branch = main
-
-#  Removed because of hugo errors
-# [submodule "content/stands/openuk"]
-# 	path = content/stands/openuk
-# 	url = https://github.com/OpenUK/fosdem-stand.git
-# 	branch = main
+[submodule "content/stands/openuk"]
+	path = content/stands/openuk
+	url = https://github.com/OpenUK/fosdem-stand.git
+	branch = main
 
 #  Removed because of hugo errors
 # [submodule "content/stands/the_libresoc_project__a_hybrid_3d_cpu_vpu_gpu"]


### PR DESCRIPTION
OpenUK has fixed the problem (https://github.com/OpenUK/fosdem-stand/pull/5). 
We can revert the exclusion now.
